### PR TITLE
Execute coqtop differently on windows.

### DIFF
--- a/autoload/coquille.py
+++ b/autoload/coquille.py
@@ -71,12 +71,20 @@ def restart_coq(*args):
     global coqtop
     if coqtop: kill_coqtop()
     try:
-        coqtop = subprocess.Popen(
-                ["coqtop", "-ideslave"] + list(args),
-                stdin = subprocess.PIPE,
-                stdout = subprocess.PIPE,
-                preexec_fn = ignore_sigint
-                )
+        if os.name == 'nt':
+            coqtop = subprocess.Popen(
+                    ["coqtop", "-ideslave"] + list(args),
+                    stdin = subprocess.PIPE,
+                    stdout = subprocess.PIPE,
+                    stderr = subprocess.STDOUT
+                    )
+        else:
+           coqtop = subprocess.Popen(
+                    ["coqtop", "-ideslave"] + list(args),
+                    stdin = subprocess.PIPE,
+                    stdout = subprocess.PIPE,
+                    preexec_fn = ignore_sigint
+                    )
     except OSError:
         print("Error: couldn't launch coqtop")
 


### PR DESCRIPTION
The coqtop fails to launch or exits on window; for example, preexec_fn is not supported on windows. This adds a special case that launches coqtop differently on windows. Tested on windows 7 amd64.
