### PR TITLE
Add experimental syntax coloring for Infos subwindow

### DIFF
--- a/autoload/coquille.vim
+++ b/autoload/coquille.vim
@@ -22,6 +22,7 @@ function! coquille#ShowPanels()
         let s:goal_buf = bufnr("%")
     rightbelow new Infos
         setlocal buftype=nofile
+        setlocal filetype=coq-infos
         setlocal noswapfile
         let s:info_buf = bufnr("%")
     execute l:winnb . 'winc w'

--- a/syntax/coq-infos.vim
+++ b/syntax/coq-infos.vim
@@ -1,29 +1,11 @@
 " Vim syntax file
-" Language:     Coq-infos
-" Filenames:    *.v
-" Maintainer:  Vincent Aravantinos <vincent.aravantinos@gmail.com>
-" Last Change: 2008 Dec 02 - Added the Program and Obligation constructions (in Coq v8.2) - with Serge Leblanc.
-"              2008 Jan 30 - Applied the improvments for all constructions, added 'with' and 'where' for
-"                            fixpoints and inductives, fixed some hard long standing bugs.
-"              2008 Jan 27 - Changed the way things are coloured, improved the efficiency of colouring.
-"              2008 Jan 25 - Added Ltac, added Notations, bugfixes.
-"              2007 Dec 1 - Added Record's.
-"              2007 Nov 28 - Added things to reuse (in other plugins) the knowledge that we are inside a proof.
-"              2007 Nov 19 - Fixed bug with comments.
-"              2007 Nov 17 - Various minor bugfixes.
-"              2007 Nov 8 - Added keywords.
-"              2007 Nov 8 - Fixed some ill-highlighting in the type of declarations.
-"              2007 Nov 8 - Fixed pb with keywords ("\<...\>" had been forgotten) 
-"                           (thanks to Vasileios Koutavas)
-"              2007 Nov 8 - Definition...Defined now works as expected, 
-"                           fixed a bug with tactics that were not recognized,
-"                           fixed other bugs
-"              2007 Nov 7 - Complete refactoring, (much) more accurate highlighting. Much bigger file...
-"              2007 Nov 7 - Added tactic colouration, added other keywords (thanks to Tom Harke)
-"              2007 Nov 6 - Added "Defined" keyword (thanks to Serge Leblanc)
-"              2007 Nov 5 - Initial version.
+" Language:    Coq-infos
+" Filenames:   *.v
+" Maintainer:  Laurent Georget <laurent@lgeorget.eu>
+" Last Change: 2015 Jul 8: Fix Print Module and Print Scope coloring
+"              2015 Jul 7: Initial version
 " License:     public domain
-" TODO: mark bad constructions (eg. Section ended but not opened)
+" TODO:        Show commands
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded

--- a/syntax/coq-infos.vim
+++ b/syntax/coq-infos.vim
@@ -39,6 +39,36 @@ syn case match
 " Various
 syn match   coqVernacPunctuation ":=\|\.\|:"
 syn match   coqIdent             contained "[_[:alpha:]][_'[:alnum:]]*"
+syn keyword coqTopLevel          Declare Type Canonical Structure Cd Coercion Derive Drop Existential
+
+" Definitions
+syn match coqDefName          "[_[:alpha:]][\._'[:alnum:]]*\_.\{-}\%(=\|:\)"me=e-1 contains=@coqTerm nextgroup=coqDefContents1,coqDefContents2
+syn region coqDefName2       contained contains=coqDefBinder,coqDefType,coqDefContents1 matchgroup=coqIdent start="[_[:alpha:]][_'[:alnum:]]*" matchgroup=NONE end="\.\_s" end=":="
+syn region coqDefContents1     contained contains=@coqTerm matchgroup=coqVernacPunctuation start=":" matchgroup=NONE end="^$" end="^\S"me=e-1
+syn region coqDefContents2     contained contains=@coqTerm matchgroup=coqVernacPunctuation start="=" matchgroup=NONE end="^$"
+
+syn region coqDefNameHidden     matchgroup=coqComment start="\*\*\* \[" matchgroup=coqComment end="\]" contains=@coqTerm,coqDefContents3
+syn region coqDefContents3     contained contains=@coqTerm matchgroup=coqVernacPunctuation start=":" end="]"me=e-1
+
+syn region coqDef          contains=coqDefName2 matchgroup=coqVernacCmd start="\<\%(Program\_s\+\)\?\%(Definition\|Let\)\>" end="\.$"me=e-1 end="\.\s"me=e-2  keepend skipnl skipwhite skipempty
+
+" Declarations
+syn region coqDecl       contains=coqIdent,coqDeclTerm,coqDeclBinder matchgroup=coqVernacCmd start="\<\%(Axiom\|Conjecture\|Hypothes[ie]s\|Parameters\?\|Variables\?\)\>" matchgroup=coqVernacCmd end="\.\_s" keepend
+syn region coqDeclBinder contained contains=coqIdent,coqDeclTerm matchgroup=coqVernacPunctuation start="(" end=")" keepend
+syn region coqDeclTerm   contained contains=@coqTerm matchgroup=coqVernacPunctuation start=":" end=")"
+syn region coqDeclTerm   contained contains=@coqTerm matchgroup=coqVernacPunctuation start=":" end="\.\_s"
+
+" Theorems
+syn region coqThm       contains=coqThmName matchgroup=coqVernacCmd start="\<\%(Program\_s\+\)\?\%(Theorem\|Lemma\|Example\|Corollary\|Remark\)\>" matchgroup=NONE end="\<\%(Qed\|Defined\|Admitted\|Abort\)\.\_s" keepend
+syn region coqThmName   contained contains=coqThmTerm,coqThmBinder matchgroup=coqIdent start="[_[:alpha:]][_'[:alnum:]]*" matchgroup=NONE end="\<\%(Qed\|Defined\|Admitted\|Abort\)\.\_s"
+syn region coqThmTerm   contained contains=@coqTerm,coqProofBody matchgroup=coqVernacCmd start=":" matchgroup=NONE end="\<\%(Qed\|Defined\|Admitted\|Abort\)\>"
+syn region coqThmBinder contained matchgroup=coqVernacPunctuation start="(" end=")" keepend
+
+" Modules
+syn region  coqModule     contains=coqIdent,coqDef,coqThm,coqDecl,coqInd,coqModuleEnd,coqStructDef matchgroup=coqTopLevel start="\<Module\>" end="^$"
+syn keyword coqModuleEnd  contained End
+syn region  coqStructDef  contained contains=coqStruct matchgroup=coqVernacPunctuation start=":=" end="End"
+syn region  coqStruct     contained contains=coqIdent,coqDef,coqThm,coqDec,coqInd matchgroup=coqTopLevel start="\<Struct\>" end="End"
 
 " Terms
 syn cluster coqTerm            contains=coqKwd,coqTermPunctuation,coqKwdMatch,coqKwdLet,coqKwdParen
@@ -51,16 +81,22 @@ syn match   coqKwd             contained "\<exists!\?"
 syn match   coqKwd             contained "|\|/\\\|\\/\|<->\|\~\|->\|=>\|{\|}\|&\|+\|-\|*\|=\|>\|<\|<="
 syn match coqTermPunctuation   contained ":=\|:>\|:\|;\|,\|||\|\[\|\]\|@\|?\|\<_\>"
 
+" Sections
+syn match coqSectionDelimiter  "^ >>>>>>>" nextgroup=coqSectionDecl skipwhite skipnl
+syn match coqSectionDecl       contained "Section" nextgroup=coqSectionName skipwhite skipnl
+syn match coqSectionName       contained "[_[:alpha:]][_'[:alnum:]]*"
+
+" Obligations
+syn region coqObligation contains=coqIdent   matchgroup=coqVernacCmd start="\<\%(\%(\%(Admit\_s\+\)\?Obligations\)\|\%(Obligation\_s\+\d\+\)\|\%(Next\_s\+Obligation\)\|Preterm\)\%(\_s\+of\)\?\>" end="\.\_s"
+syn region coqObligation contains=coqOblOf   matchgroup=coqVernacCmd start="\<Solve\_s\+Obligations\>" end="\.\_s" keepend
+syn region coqOblOf      contains=coqIdent,coqOblUsing matchgroup=coqVernacCmd start="\<of\>" end="\.\_s" keepend
+syn region coqObligation contains=coqOblUsing   matchgroup=coqVernacCmd start="\<Solve\_s\+All\_s\+Obligations\>" end="\.\_s" keepend
+syn region coqOblUsing   contains=coqLtac   matchgroup=coqVernacCmd start="\<using\>" end="\.\_s"
+syn region coqObligation contains=coqOblExpr matchgroup=coqVernacCmd start="\<Obligations\_s\+Tactic\>" end="\.\_s" keepend
+syn region coqOblExpr    contains=coqLtac   matchgroup=coqVernacPunctuation start=":=" end="\.\_s"
+
 " Compute
 syn region coqComputed  contains=@coqTerm matchgroup=coqVernacPunctuation start="^\s*=" matchgroup=NONE end="^$"
-
-" Definitions
-syn match coqDefName          "[_[:alpha:]][_'[:alnum:]]*\_.\{-}\%(=\|:\)" contains=@coqTerm,coqDefContents1,coqDefContents2
-syn region coqDefContents1     contained contains=@coqTerm matchgroup=coqVernacPunctuation start=":" matchgroup=NONE end="^$" end="^\S"me=e-1
-syn region coqDefContents2     contained contains=@coqTerm matchgroup=coqVernacPunctuation start="=" matchgroup=NONE end="^$" end="^\S"me=e-1
-
-syn region coqDefNameHidden     matchgroup=coqComment start="\*\*\* \[" matchgroup=coqComment end="\]" contains=@coqTerm,coqDefContents3
-syn region coqDefContents3     contained contains=@coqTerm matchgroup=coqVernacPunctuation start=":" end="]"me=e-1
 
 " Notations
 syn region coqNotationDef       contains=coqNotationString,coqNotationTerm matchgroup=coqVernacCmd start="\<Notation\>\%(\s*\<Scope\>\)\?" end="^$"
@@ -69,6 +105,11 @@ syn region coqNotationScope     contained contains=@coqTerm,coqNotationFormat ma
 syn region coqNotationFormat    contained contains=coqNotationKwd,coqString matchgroup=coqVernacPunctuation start="(" end=")"
 
 syn match  coqNotationKwd    contained "default interpretation"
+
+" Scopes
+syn region coqScopeDef       contains=coqNotationString,coqScopeTerm,coqScopeSpecification matchgroup=coqVernacCmd start="\<Scope\>" end="^$"
+syn region coqScopeTerm      contained matchgroup=coqVernacPunctuation start=":=" matchgroup=NONE end="\""me=e-1 end="^$"me=e-1 contains=@coqTerm
+syn keyword coqScopeSpecification contained Delimiting key is Bound to class
 
 syn region coqNotationString contained start=+"+ skip=+""+ end=+"+ extend
 
@@ -136,9 +177,13 @@ if version >= 508 || !exists("did_coq_infos_syntax_inits")
  " VERNACULAR COMMANDS
  HiLink coqVernacCmd         coqVernacular
  HiLink coqVernacPunctuation coqVernacular
+ HiLink coqTopLevel          coqVernacular
+ HiLink coqSectionDecl       coqTopLevel
+ HiLink coqModuleEnd         coqTopLevel
 
  " DEFINED OBJECTS
  HiLink coqIdent                     Identifier
+ HiLink coqSectionName               Identifier
  HiLink coqDefName                   Identifier
  HiLink coqDefNameHidden             Identifier
  HiLink coqNotationString coqIdent
@@ -150,8 +195,9 @@ if version >= 508 || !exists("did_coq_infos_syntax_inits")
  " NOTATION SPECIFIC ("at level", "format", etc)
  HiLink coqNotationKwd               Special
 
- " ARGUMENT SPECIFICATIONS (SCOPES...)
+ " SPECIFICATIONS
  HiLink coqArgumentSpecificationKeywords      Underlined
+ HiLink coqScopeSpecification                 Underlined
 
  " WARNINGS AND ERRORS
  HiLink coqBad                       WarningMsg
@@ -163,6 +209,7 @@ if version >= 508 || !exists("did_coq_infos_syntax_inits")
  " USUAL VIM HIGHLIGHTINGS
    " Comments
    HiLink coqComment                   Comment
+   HiLink coqSectionDelimiter          Comment
    HiLink coqProofComment coqComment
 
    " Todo

--- a/syntax/coq-infos.vim
+++ b/syntax/coq-infos.vim
@@ -1,0 +1,197 @@
+" Vim syntax file
+" Language:     Coq-infos
+" Filenames:    *.v
+" Maintainer:  Vincent Aravantinos <vincent.aravantinos@gmail.com>
+" Last Change: 2008 Dec 02 - Added the Program and Obligation constructions (in Coq v8.2) - with Serge Leblanc.
+"              2008 Jan 30 - Applied the improvments for all constructions, added 'with' and 'where' for
+"                            fixpoints and inductives, fixed some hard long standing bugs.
+"              2008 Jan 27 - Changed the way things are coloured, improved the efficiency of colouring.
+"              2008 Jan 25 - Added Ltac, added Notations, bugfixes.
+"              2007 Dec 1 - Added Record's.
+"              2007 Nov 28 - Added things to reuse (in other plugins) the knowledge that we are inside a proof.
+"              2007 Nov 19 - Fixed bug with comments.
+"              2007 Nov 17 - Various minor bugfixes.
+"              2007 Nov 8 - Added keywords.
+"              2007 Nov 8 - Fixed some ill-highlighting in the type of declarations.
+"              2007 Nov 8 - Fixed pb with keywords ("\<...\>" had been forgotten) 
+"                           (thanks to Vasileios Koutavas)
+"              2007 Nov 8 - Definition...Defined now works as expected, 
+"                           fixed a bug with tactics that were not recognized,
+"                           fixed other bugs
+"              2007 Nov 7 - Complete refactoring, (much) more accurate highlighting. Much bigger file...
+"              2007 Nov 7 - Added tactic colouration, added other keywords (thanks to Tom Harke)
+"              2007 Nov 6 - Added "Defined" keyword (thanks to Serge Leblanc)
+"              2007 Nov 5 - Initial version.
+" License:     public domain
+" TODO: mark bad constructions (eg. Section ended but not opened)
+
+" For version 5.x: Clear all syntax items
+" For version 6.x: Quit when a syntax file was already loaded
+if version < 600
+ syntax clear
+elseif exists("b:current_syntax") && b:current_syntax == "coq-infos"
+ finish
+endif
+
+" Coq is case sensitive.
+syn case match
+
+syn cluster coqVernac contains=coqRequire,coqCheck,coqEval,coqNotation,coqTacNotation,coqDecl,coqThm,coqLtacDecl,coqDef,coqFix,coqInd,coqRec,coqShow
+
+" Various
+syn match   coqVernacPunctuation ":=\|\.\|:"
+syn match   coqIdent             contained "[_[:alpha:]][_'[:alnum:]]*"
+syn keyword coqTopLevel          Declare Type Canonical Structure Cd Coercion Derive Drop Existential
+"...
+syn keyword coqVernacCmd         Functional Scheme Back Combined
+syn keyword coqFeedback          Show About Print
+
+" Terms
+syn cluster coqTerm            contains=coqKwd,coqTermPunctuation,coqKwdMatch,coqKwdLet,coqKwdParen
+syn region coqKwdMatch         contained contains=@coqTerm matchgroup=coqKwd start="\<match\>" end="\<with\>"
+syn region coqKwdLet           contained contains=@coqTerm matchgroup=coqKwd start="\<let\>"   end=":="
+syn region coqKwdParen         contained contains=@coqTerm matchgroup=coqTermPunctuation start="(" end=")" keepend extend
+syn keyword coqKwd             contained else end exists2 fix forall fun if in struct then as return
+syn match   coqKwd             contained "\<where\>"
+syn match   coqKwd             contained "\<exists!\?"
+syn match   coqKwd             contained "|\|/\\\|\\/\|<->\|\~\|->\|=>\|{\|}\|&\|+\|-\|*\|=\|>\|<\|<="
+syn match coqTermPunctuation   contained ":=\|:>\|:\|;\|,\|||\|\[\|\]\|@\|?\|\<_\>"
+
+" Compute
+syn region coqComputed  contains=@coqTerm matchgroup=coqVernacPunctuation start="^\s*=" matchgroup=NONE end="^$"
+
+" Definitions
+syn region coqDefName          start="[_[:alpha:]][_'[:alnum:]]*" skip="\%(=\|:\)" end="\%(=\|:\)"me=e-1 contains=coqDefContents1,coqDefContents2
+syn region coqDefContents1     contained contains=@coqTerm matchgroup=coqVernacPunctuation start=":" matchgroup=NONE end="^$"  matchgroup=NONE end="^\S"me=e-1
+syn region coqDefContents2     contained contains=@coqTerm matchgroup=coqVernacPunctuation start="=" matchgroup=NONE end="^$"
+
+" Notations
+syn region coqNotationDef       contains=coqNotationString,coqNotationTerm matchgroup=coqVernacCmd start="\<Notation\>\%(\s*\<Scope\>\)\?" end="^$"
+syn region coqNotationTerm      contained matchgroup=coqVernacPunctuation start=":=" matchgroup=NONE end="\""me=e-1 end="^$"me=e-1 contains=coqNotationScope,coqNotationFormat
+syn region coqNotationScope     contained contains=@coqTerm,coqNotationFormat matchgroup=coqVernacPunctuation start=":" end="\""me=e-1 end="^$"
+syn region coqNotationFormat    contained contains=coqNotationKwd,coqString matchgroup=coqVernacPunctuation start="(" end=")"
+
+syn match   coqNotationKwd contained "at \(next \)\?level"
+syn match   coqNotationKwd contained "\(no\|left\|right\) associativity"
+syn match   coqNotationKwd contained "only parsing"
+syn match   coqNotationKwd contained "default interpretation"
+syn match   coqNotationKwd contained "(\|,\|)\|:"
+syn keyword coqNotationKwd contained ident global bigint format
+
+syn region coqNotationString contained start=+"+ skip=+""+ end=+"+ extend
+
+"Inductives and Constants
+syn region coqInd            contains=coqIndBody start="\<\%(\%(Co\)\?Inductive\|Constant\)\>" matchgroup=coqVernacPunctuation end="^\S"me=e-1 keepend
+syn region coqIndBody     contained contains=coqIdent,coqIndTerm,coqIndBinder matchgroup=coqVernacCmd start="\%(Co\)\?Inductive\|Constant" start="\<with\>" matchgroup=NONE end="^\S"me=e-1
+syn region coqIndBinder      contained contains=coqIndBinderTerm matchgroup=coqVernacPunctuation start="("  end=")" keepend
+syn region coqIndBinderTerm  contained contains=@coqTerm matchgroup=coqVernacPunctuation start=":" end=")"
+syn region coqIndTerm        contained contains=@coqTerm,coqIndContent matchgroup=coqVernacPunctuation start=":" matchgroup=NONE end="^\S"me=e-1
+syn region coqIndContent     contained contains=coqIndConstructor start=":=" end="^\S"me=e-1
+syn region coqIndConstructor contained contains=coqConstructor,coqIndBinder,coqIndConsTerm,coqIndNot,coqIndBody matchgroup=coqVernacPunctuation start=":=\%(\_s*|\)\?" start="|" matchgroup=NONE end="^\S"me=e-1
+syn region coqIndConsTerm    contained contains=coqIndBody,@coqTerm,coqIndConstructor,coqIndNot matchgroup=coqConstructor start=":" matchgroup=NONE end="^\S"me=e-1
+syn region coqIndNot         contained contains=coqNotationString,coqIndNotTerm matchgroup=coqVernacCmd start="\<where\>" end="^\S"me=e-1
+syn region coqIndNotTerm     contained contains=@coqTerm,coqIndNotScope,coqIndBody matchgroup=coqVernacPunctuation start=":=" end="^\S"me=e-1
+syn region coqIndNotScope    contained contains=coqIndBody matchgroup=coqVernacPunctuation start=":" end="^\S"me=e-1
+syn match  coqConstructor    contained "[_[:alpha:]][_'[:alnum:]]*"
+
+" Records
+syn region coqRec        contains=coqRecProfile start="\<Record\>" matchgroup=coqVernacPunctuation end="^\S"me=e-1 keepend
+syn region coqRecProfile contained contains=coqIdent,coqRecTerm,coqRecBinder matchgroup=coqVernacCmd start="Record" matchgroup=NONE end="^\S"me=e-1
+syn region coqRecBinder  contained contains=@coqTerm matchgroup=coqTermPunctuation start="("  end=")"
+syn region coqRecTerm    contained contains=@coqTerm,coqRecContent matchgroup=coqVernacPunctuation start=":"  end="^\S"me=e-1
+syn region coqRecContent contained contains=coqConstructor,coqRecStart matchgroup=coqVernacPunctuation start=":=" end="^\S"me=e-1
+syn region coqRecStart   contained contains=coqRecField,@coqTerm start="{" matchgroup=coqVernacPunctuation end="}" keepend
+syn region coqRecField   contained contains=coqField matchgroup=coqVernacPunctuation start="{" end=":"
+syn region coqRecField   contained contains=coqField matchgroup=coqVernacPunctuation start=";" end=":"
+syn match coqField       contained "[_[:alpha:]][_'[:alnum:]]*"
+
+" Warning and errors
+syn match   coqBad               contained ".*\%(w\|W\)arnings\?"
+syn match   coqVeryBad           contained ".*\%(e\|E\)rrors\?"
+syn region  coqWarningMsg        matchgroup=coqBad start="^.*\%(w\|W\)arnings\?:" end="$"
+syn region  coqErrorMsg          matchgroup=coqVeryBad start="^.*\%(e\|E\)rrors\?:" end="$"
+
+" Various (High priority)
+syn region  coqComment           containedin=ALL contains=coqComment,coqTodo start="(\*" end="\*)" extend keepend
+syn keyword coqTodo              contained TODO FIXME XXX NOTE
+syn region  coqString            start=+"+ skip=+""+ end=+"+ extend
+
+" Synchronization
+syn sync minlines=50
+syn sync maxlines=500
+
+" Define the default highlighting.
+" For version 5.7 and earlier: only when not done already
+" For version 5.8 and later: only when an item doesn't have highlighting yet
+if version >= 508 || !exists("did_coq_syntax_inits")
+ if version < 508
+  let did_coq_syntax_inits = 1
+  command -nargs=+ HiLink hi link <args>
+ else
+  command -nargs=+ HiLink hi def link <args>
+ endif
+
+ " PROOFS
+ HiLink coqTactic                    Keyword
+ HiLink coqLtac coqTactic
+ HiLink coqProofKwd coqTactic
+ HiLink coqProofPunctuation coqTactic
+ HiLink coqTacticKwd coqTactic
+ HiLink coqTacNotationKwd coqTactic
+ HiLink coqEvalFlag coqTactic
+ " Exception
+ HiLink coqProofDot coqVernacular
+
+ " PROOF DELIMITERS ("Proof", "Qed", "Defined", "Save")
+ HiLink coqProofDelim                Underlined
+
+ " TERMS AND TYPES
+ HiLink coqTerm                      Type
+ HiLink coqKwd             coqTerm
+ HiLink coqTermPunctuation coqTerm
+
+ " VERNACULAR COMMANDS
+ HiLink coqVernacular                PreProc
+ HiLink coqVernacCmd         coqVernacular
+ HiLink coqVernacPunctuation coqVernacular
+ HiLink coqHint              coqVernacular
+ HiLink coqFeedback          coqVernacular
+ HiLink coqTopLevel          coqVernacular
+
+ " DEFINED OBJECTS
+ HiLink coqIdent                     Identifier
+ HiLink coqDefName                   Identifier
+ HiLink coqNotationString coqIdent
+
+ " CONSTRUCTORS AND FIELDS
+ HiLink coqConstructor               Keyword
+ HiLink coqField coqConstructor
+
+ " NOTATION SPECIFIC ("at level", "format", etc)
+ HiLink coqNotationKwd               Special
+
+ " WARNINGS AND ERRORS
+ HiLink coqBad                       WarningMsg
+ HiLink coqVeryBad                   ErrorMsg
+ HiLink coqWarningMsg                WarningMsg
+ HiLink coqBad                       WarningMsg
+
+
+ " USUAL VIM HIGHLIGHTINGS
+   " Comments
+   HiLink coqComment                   Comment
+   HiLink coqProofComment coqComment
+
+   " Todo
+   HiLink coqTodo                      Todo
+
+   " Errors
+   HiLink coqError                     Error
+
+   " Strings
+   HiLink coqString                    String
+
+ delcommand HiLink
+endif
+
+let b:current_syntax = "coq-infos"


### PR DESCRIPTION
Hello,

this patch introduce (separately from the Goals syntax coloring),
the syntax coloring for the Infos subwindow.
It is experimental due to the huge number of kinds of answers
which can be displayed in this window, each with its proper syntax
but it suppports:

- Print commands, including Print Module and Print Scope
- Locate
- Search, SearchAbout, SearchPattern
- Compute
- Syntax errors and warnings messages
![infos-print_section](https://cloud.githubusercontent.com/assets/4492093/8694877/33cbd8c0-2ae2-11e5-9651-b417c31312c1.png)
![infos-locate](https://cloud.githubusercontent.com/assets/4492093/8694879/33ced1a6-2ae2-11e5-8cd4-6a7916b58206.png)
![infos-search](https://cloud.githubusercontent.com/assets/4492093/8694880/33cef9d8-2ae2-11e5-98de-003f8bc61aa8.png)
![infos-print](https://cloud.githubusercontent.com/assets/4492093/8694882/33d0b566-2ae2-11e5-88fb-94782032ead7.png)
![infos-warnings compute](https://cloud.githubusercontent.com/assets/4492093/8694878/33cdd8b4-2ae2-11e5-9dee-618f40af1cb7.png)
![infos-syntax](https://cloud.githubusercontent.com/assets/4492093/8694881/33d034c4-2ae2-11e5-99d0-0db901580b04.png)





