### PR TITLE
Auto remove cursor as default behavior

### DIFF
--- a/autoload/coquille.vim
+++ b/autoload/coquille.vim
@@ -2,7 +2,7 @@ let s:coq_running=0
 let s:current_dir=expand("<sfile>:p:h") 
 
 if !exists('coquille_auto_move')
-    let g:coquille_auto_move="false"
+    let g:coquille_auto_move="true"
 endif
 
 " Load vimbufsync if not already done


### PR DESCRIPTION
Mentioned at #43.

as it is a default behavior to move cursor with the proof step on other Coq IDE e.g. proof-general or CoqIDE, i can not find any reason why we don't comply with this convention. 😃 