### PR TITLE
Make xml re-parsing a little faster

### DIFF
--- a/autoload/coqtop.py
+++ b/autoload/coqtop.py
@@ -1,7 +1,7 @@
 import os
 import re
 import subprocess
-import xml.etree.ElementTree as ET
+import xml.etree.cElementTree as ET
 import signal
 
 from collections import deque, namedtuple
@@ -165,7 +165,7 @@ def get_answer():
     data = ''
     while True:
         try:
-            data += os.read(fd, 0x4000)
+            data += os.read(fd, 0x10000)
             try:
                 elt = ET.fromstring('<coqtoproot>' + escape(data) + '</coqtoproot>')
                 shouldWait = True


### PR DESCRIPTION
Since #45 got fixed, I would get hangs with the python process stuck at 100% CPU usage. After some eyeballing with @let-def today, it turned out that python was drowning in XML reparsing. Coq seems to be sending much larger chunks of data than it used to.

A really, really, really quick-and-duct-tape fix:
* increase reads (64K is the Linux default pipe buffer size and a reasonable number all-around); and
* force-load the C version of Elementtree (3.5 auto-switches, but 2.7 uses the python code unless told otherwise).