### PR TITLE
Miscellaneous minimal syntax fixes

### DIFF
--- a/syntax/coq-goals.vim
+++ b/syntax/coq-goals.vim
@@ -26,7 +26,7 @@ syn match   coqNumberGoals       '\d\+ subgoals\?' nextgroup=coqGoal
 
 " Hypothesis
 syn region  coqHypothesisBlock  contains=coqHypothesis start="^[_[:alpha:]][_'[:alnum:]]*\s*:" end="^$" keepend
-syn region  coqHypothesis       contained contains=coqHypothesisBody matchgroup=coqIdent start="^[_[:alpha:]][_'[:alnum:]]*" matchgroup=NONE end="^\S"me=e-1
+syn region  coqHypothesis       contained contains=coqHypothesisBody matchgroup=coqIdent start="^\([_[:alpha:]][_'[:alnum:]]*,\s*\)*[_[:alpha:]][_'[:alnum:]]*" matchgroup=NONE end="^\S"me=e-1
 syn region  coqHypothesisBody   contained contains=@coqTerm matchgroup=coqVernacPunctuation start=":" matchgroup=NONE end="^\S"me=e-1
 
 " Separator

--- a/syntax/coq.vim
+++ b/syntax/coq.vim
@@ -226,7 +226,7 @@ syn region coqProofEnder contained contains=coqIdent matchgroup=coqProofDelim st
 syn keyword coqTactic    contained absurd apply assert assumption auto
 syn keyword coqTactic    contained case[_eq] change clear[body] cofix cbv compare compute congruence constructor contradiction cut[rewrite]
 syn keyword coqTactic    contained decide decompose dependent destruct discriminate double
-syn keyword coqTactic    contained eapply eassumption econstructor elim[type] equality evar exact eexact exists
+syn keyword coqTactic    contained eapply eassumption econstructor elim[type] equality evar exact eexact exists exfalso
 syn keyword coqTactic    contained fix f_equal fold functional generalize hnf
 syn keyword coqTactic    contained idtac induction injection instantiate intro[s] intuition inversion[_clear]
 syn keyword coqTactic    contained lapply left move omega pattern pose proof quote

--- a/syntax/coq.vim
+++ b/syntax/coq.vim
@@ -197,7 +197,7 @@ syn region coqDeclTerm   contained contains=@coqTerm matchgroup=coqVernacPunctua
 syn region coqDeclTerm   contained contains=@coqTerm matchgroup=coqVernacPunctuation start=":" end="\.\_s"
 
 " Theorems
-syn region coqThm       contains=coqThmName matchgroup=coqVernacCmd start="\<\%(Program\_s\+\)\?\%(Theorem\|Lemma\|Example\|Corollary\|Remark\)\>" matchgroup=NONE end="\<\%(Qed\|Defined\|Admitted\|Abort\)\.\_s" keepend
+syn region coqThm       contains=coqThmName matchgroup=coqVernacCmd start="\<\%(Program\_s\+\)\?\%(Theorem\|Lemma\|Example\|Corollary\|Remark\|Fact\)\>" matchgroup=NONE end="\<\%(Qed\|Defined\|Admitted\|Abort\)\.\_s" keepend
 syn region coqThmName   contained contains=coqThmTerm,coqThmBinder matchgroup=coqIdent start="[_[:alpha:]][_'[:alnum:]]*" matchgroup=NONE end="\<\%(Qed\|Defined\|Admitted\|Abort\)\.\_s"
 syn region coqThmTerm   contained contains=@coqTerm,coqProofBody matchgroup=coqVernacCmd start=":" matchgroup=NONE end="\<\%(Qed\|Defined\|Admitted\|Abort\)\>"
 syn region coqThmBinder contained matchgroup=coqVernacPunctuation start="(" end=")" keepend


### PR DESCRIPTION
The first commit add colorations for `Fact` theorems.

The second commit handle case where there are hypothesis like `x, y, z : nat`, coloring the whole `x, y, z`, not only `x`.