### PR TITLE
Decode the input before building XML commands.

### DIFF
--- a/autoload/coqtop.py
+++ b/autoload/coqtop.py
@@ -104,7 +104,7 @@ def encode_value(v):
         xml = build('bool', str(v).lower())
         xml.text = str(v)
         return xml
-    elif isinstance(v, str):
+    elif isinstance(v, str) or isinstance(v, unicode):
         xml = build('string')
         xml.text = v
         return xml
@@ -244,7 +244,7 @@ def cur_state():
 
 def advance(cmd, encoding = 'utf-8'):
     global state_id
-    r = call('Add', ((cmd, -1), (cur_state(), True)), encoding)
+    r = call('Add', ((cmd.decode(encoding), -1), (cur_state(), True)), encoding)
     if r is None:
         return r
     if isinstance(r, Err):


### PR DESCRIPTION
As spotted in issue #53, Coquille chokes on non-ASCII input because of encoding problems and Python throwing `UnicodeDecodeError` exceptions. This is a simple fix for the issue, it consists in

- decoding the text from Vim's buffer when creating an XML command (the data we get from Vim is a byte string as a Python `str`, we turn it into a `unicode` following the buffer's encoding)
- accepting the `unicode` type in command encoding.

My first tests work fine but it surely deserves to be checked.