### PR TITLE
Support commentstring

### DIFF
--- a/ftdetect/coq.vim
+++ b/ftdetect/coq.vim
@@ -1,1 +1,3 @@
 au BufRead,BufNewFile *.v set filetype=coq
+
+au FileType coq setlocal commentstring=(*%s*)


### PR DESCRIPTION
can be used by vim-commentary for instance or when creating marker folds.