### PR TITLE
Fix issue #61 by suppressing Coqtop stderr output

### DIFF
--- a/autoload/coqtop.py
+++ b/autoload/coqtop.py
@@ -223,6 +223,8 @@ def restart_coq(*args):
                 options + list(args)
               , stdin = subprocess.PIPE
               , stdout = subprocess.PIPE
+              , stderr = subprocess.PIPE # Do this so that the stderr output doesn't randomly appear on the screen
+                                         # TODO: Maybe display the stderr output somewhere useful?
               , preexec_fn = ignore_sigint
             )
 


### PR DESCRIPTION
This should fix issue #61.

I tried doing what the code for Windows NT did and redirect the stderr
output to stdout, but that freezes my Vim process for some reason. So I
just send it to a pipe that is never read from.