### PR TITLE
Support Coq 8.9.0

### DIFF
--- a/autoload/coqtop.py
+++ b/autoload/coqtop.py
@@ -206,8 +206,7 @@ def send_cmd(cmd):
 def restart_coq(*args):
     global coqtop, root_state, state_id
     if coqtop: kill_coqtop()
-    options = [ 'coqtop'
-              , '-ideslave'
+    options = [ 'coqidetop'
               , '-main-channel'
               , 'stdfds'
               , '-async-proofs'


### PR DESCRIPTION
This PR contains a simple fix to use `coqidetop` to support coq v8.9.0.
Also this will fix #75 in pathogen-bundle branch.